### PR TITLE
Sprint

### DIFF
--- a/src/BuilderException.php
+++ b/src/BuilderException.php
@@ -13,6 +13,6 @@ class BuilderException extends Exception
 
     public static function notSettable(string $property, string $class): self
     {
-        return new self(sprintf('No property with name: %s found in class: %', $property, $class));
+        return new self(sprintf('No property with name: %s found in class: %s', $property, $class));
     }
 }

--- a/src/BuilderException.php
+++ b/src/BuilderException.php
@@ -8,11 +8,11 @@ class BuilderException extends Exception
 {
     public static function invalidMethodName(string $methodName): self
     {
-        return new self("Builder method names must start with \"with\". Invalid method name: $methodName");
+        return new self(sprintf('Builder method names must start with "with". Invalid method name: %s', $methodName));
     }
 
     public static function notSettable(string $property, string $class): self
     {
-        return new self("No property with name \"$$property\" found in class $class");
+        return new self(sprintf('No property with name: %s found in class: %', $property, $class));
     }
 }


### PR DESCRIPTION
Hello,

Here is a better way to format errors. Avoids antislashes or double dollars!
